### PR TITLE
for_each fail it random_string is referenced

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -10,70 +10,18 @@ data "aws_subnet_ids" "main" {
   vpc_id = data.aws_vpc.main.id
 }
 
-## Basic fargate cluster with monitoring and service from telia oss fargate module
-
-module "basic_fargate" {
-  source = "../"
-
-  name_prefix = "fargate-basic"
-  vpc_id      = data.aws_vpc.main.id
-  subnet_ids  = data.aws_subnet_ids.main.ids
-
-  internal_elb = false
-
-  tags = {
-    environment = "dev"
-  }
+resource "random_string" "word" {
+  length  = 4
+  upper   = true
+  lower   = true
+  number  = true
+  special = false
 }
-
-module "fargate_service" {
-  source = "../fargate-service"
-
-  name_prefix          = "hello-world"
-  vpc_id               = data.aws_vpc.main.id
-  private_subnet_ids   = data.aws_subnet_ids.main.ids
-  lb_arn               = module.basic_fargate.load_balancer_arn
-  cluster_id           = module.basic_fargate.cluster_id
-  task_container_image = "crccheck/hello-world:latest"
-
-  // public ip is needed for default vpc, default is false
-  task_container_assign_public_ip = true
-
-  // port, default protocol is HTTP
-  task_container_port = 8000
-
-  task_container_environment = {
-    TEST_VARIABLE = "TEST_VALUE"
-  }
-
-  health_check = {
-    port = "traffic-port"
-    path = "/"
-  }
-
-  service_listner_rules = [
-    {
-      field = "host-header"
-      values = [
-      "hello-world.com"]
-    }
-  ]
-
-  tags = {
-    environment = "dev"
-    terraform   = "True"
-  }
-}
-
-## More complex example with container definitions in the same module
-#
-# Difference is that due to interpolation, you have to have only static values in containers_definitions map
-#
 
 module "fargate" {
   source = "../"
 
-  name_prefix = "fargate"
+  name_prefix = "fargate-test-cluster"
   vpc_id      = data.aws_vpc.main.id
   subnet_ids  = data.aws_subnet_ids.main.ids
 
@@ -97,6 +45,10 @@ module "fargate" {
       task_tags = {
         terraform = "True"
       }
+      scaling_enable = false
+      service_registry_arn = ""
+      repository_credentials_kms_key = ""
+      task_repository_credentials = ""
     }
     hellonginx = {
       task_container_image            = "nginx:latest"
@@ -106,6 +58,10 @@ module "fargate" {
         {
           name  = "TEST_VARIABLE"
           value = "TEST_VALUE"
+        },
+        {
+          name  = "RANDOM_VARIABLE"
+          value = random_string.word.result
         }
       ]
       health_check = {
@@ -115,20 +71,19 @@ module "fargate" {
       task_tags = {
         terraform = "True"
       }
-
+      scaling_enable = true
+      service_registry_arn = ""
+      repository_credentials_kms_key = ""
+      task_repository_credentials = ""
     }
   }
+
   tags = {
     environment = "dev"
   }
 }
 
-output "load_balancer_domain_fargate" {
+output "load_balancer_domain" {
   description = "Get DNS record of load balancer"
   value       = module.fargate.load_balancer_domain
-}
-
-output "load_balancer_domain_basic_fargate" {
-  description = "Get DNS record of load balancer"
-  value       = module.basic_fargate.load_balancer_domain
 }

--- a/fargate/main.tf
+++ b/fargate/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy" "task_execution" {
 }
 
 resource "aws_iam_role_policy" "read_repository_credentials" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "task_repository_credentials", "") != "" }
+  for_each = { for i, z in var.containers_definitions : i => z if z.task_repository_credentials != "" }
   name     = "${lookup(var.containers_definitions[each.key], "task_container_name", each.key)}-read-repository-credentials"
   role     = aws_iam_role.execution[each.key].id
   policy   = data.aws_iam_policy_document.read_repository_credentials[each.key].json
@@ -277,7 +277,7 @@ EOF
 }
 
 resource "aws_ecs_service" "service_with_no_service_registries" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "service_registry_arn", "") != "" }
+  for_each = { for i, z in var.containers_definitions : i => z if z.service_registry_arn != "" }
 
   depends_on                         = [null_resource.lb_exists]
   name                               = each.key
@@ -319,7 +319,7 @@ resource "aws_ecs_service" "service_with_no_service_registries" {
 }
 
 resource "aws_ecs_service" "service" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "service_registry_arn", "") == "" }
+  for_each = { for i, z in var.containers_definitions : i => z if z.service_registry_arn == "" }
 
   depends_on                         = [null_resource.lb_exists]
   name                               = each.key

--- a/fargate/policies.tf
+++ b/fargate/policies.tf
@@ -50,12 +50,12 @@ data "aws_iam_policy_document" "task_execution_permissions" {
 }
 
 data "aws_kms_key" "secretsmanager_key" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "repository_credentials_kms_key", "") != "" }
+  for_each = { for i, z in var.containers_definitions : i => z if z.repository_credentials_kms_key != "" }
   key_id   = lookup(var.containers_definitions[each.key], "repository_credentials_kms_key", "")
 }
 
 data "aws_iam_policy_document" "read_repository_credentials" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "repository_credentials_kms_key", "") != "" }
+  for_each = { for i, z in var.containers_definitions : i => z if z.repository_credentials_kms_key != "" }
   statement {
     effect = "Allow"
 

--- a/fargate/scaling.tf
+++ b/fargate/scaling.tf
@@ -1,6 +1,6 @@
 
 resource "aws_appautoscaling_target" "ecs_target" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "scaling_enable", false) == true }
+  for_each = { for i, z in var.containers_definitions : i => z if z.scaling_enable == true }
 
   max_capacity       = lookup(var.containers_definitions[each.key], "scaling_max_capacity", 4)
   min_capacity       = lookup(var.containers_definitions[each.key], "scaling_min_capacity", 1)
@@ -10,7 +10,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
 }
 
 resource "aws_appautoscaling_policy" "ecs_scaling_policy" {
-  for_each = { for i, z in var.containers_definitions : i => z if lookup(z, "scaling_enable", false) == true }
+  for_each = { for i, z in var.containers_definitions : i => z if z.scaling_enable == true }
 
   name               = "${each.key}:${lookup(var.containers_definitions[each.key], "scaling_metric", "ECSServiceAverageCPUUtilization")}:${aws_appautoscaling_target.ecs_target[each.key].resource_id}"
   policy_type        = "TargetTrackingScaling"


### PR DESCRIPTION
for_each filtering fails with "The "for_each" value depends on resource
attributes that cannot be determined until apply"

it turns out that failure is caused by the functions wich are applyed on
these half-defined resources: like lookup(), merge(), etc. which do analyze
map objects to produce a result.

Explicitly defining keys which are used in filter expressions eliminate
the issue.